### PR TITLE
Pinning mock version because of setuptools req

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(name='talon',
           "dnspython==1.11.1",
           "html2text",
           "nose==1.2.1",
-          "mock",
+          "mock==1.0.1",
           "coverage",
           "flanker",
           "cssselect"


### PR DESCRIPTION
New versions of `mock` require `setuptools >= 17.1`, something that IronWorkers do not support at the moment. I think it is simpler to simply regress `mock`.

Sorry for the branch name, I've done this directly from the GitHub UI.